### PR TITLE
httplib2 hangs sometimes in auth.py

### DIFF
--- a/pydrive/auth.py
+++ b/pydrive/auth.py
@@ -104,7 +104,7 @@ class GoogleAuth(ApiAttributeMixin, object):
   http = ApiAttribute('http')
   service = ApiAttribute('service')
 
-  def __init__(self, settings_file='settings.yaml'):
+  def __init__(self, settings_file='settings.yaml',http_timeout=None):
     """Create an instance of GoogleAuth.
 
     This constructor just sets the path of settings file.
@@ -113,6 +113,7 @@ class GoogleAuth(ApiAttributeMixin, object):
     :param settings_file: path of settings file. 'settings.yaml' by default.
     :type settings_file: str.
     """
+    self.http_timeout=http_timeout
     ApiAttributeMixin.__init__(self)
     self.client_config = {}
     try:
@@ -369,7 +370,7 @@ class GoogleAuth(ApiAttributeMixin, object):
       raise RefreshError('No refresh_token found.'
                          'Please set access_type of OAuth to offline.')
     if self.http is None:
-      self.http = httplib2.Http()
+      self.http = httplib2.Http(timeout=self.http_timeout)
     try:
       self.credentials.refresh(self.http)
     except AccessTokenRefreshError, error:
@@ -415,7 +416,7 @@ class GoogleAuth(ApiAttributeMixin, object):
     :raises: AuthenticationError
     """
     if self.http is None:
-      self.http = httplib2.Http()
+      self.http = httplib2.Http(timeout=self.http_timeout)
     if self.access_token_expired:
       raise AuthenticationError('No valid credentials provided to authorize')
     self.http = self.credentials.authorize(self.http)


### PR DESCRIPTION
Right now I'm having to superclass GoogleAuth because when downloads are done in large batches, httplib2 likes to hang sometimes. It'd be really awesome if we could specify a timeout to be passed into the Http() constructor calls.