### PR TITLE
Adding initial tox configuration (2.6, 2.7, 3.3, 3.4)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py26, py27, py33, py34
+
+[testenv]
+changedir = {toxinidir}/pydrive/test
+deps =
+    pytest
+    httplib2
+    PyYAML
+    git+https://github.com/google/google-api-python-client.git
+commands =
+    py.test -v -s


### PR DESCRIPTION
Adding a tox testing environment for testing in multiple versions of python.  Python 3 tests will fail until my other PR gets merged.