### PR TITLE
Add method to return Google Drive information

### DIFF
--- a/pydrive/drive.py
+++ b/pydrive/drive.py
@@ -36,3 +36,10 @@ class GoogleDrive(ApiAttributeMixin, object):
     :returns: pydrive.files.GoogleDriveFileList -- initialized with auth of this instance.
     """
     return GoogleDriveFileList(auth=self.auth, param=param)
+
+  def AboutDrive(self):
+    """Return information about the Google Drive of the auth instance.
+
+    :returns: A dictionary of Google Drive information like user, usage, quota etc.
+    """
+    return self.auth.service.about().get().execute()


### PR DESCRIPTION
A method is added to drive.py to return the Google Drive's
information pointed by its auth instance. The return value
is a dictionary containing Google Drive information like,
logged user, current usage, total quota, etc.

Signed-off-by: Himanshu Chauhan <hschauhan@nulltrace.org>