### PR TITLE
Fix issue #52 missing obj in __del__

### DIFF
--- a/pydrive/apiattr.py
+++ b/pydrive/apiattr.py
@@ -21,8 +21,11 @@ class ApiAttribute(object):
     if obj.dirty.get(self.name) is not None:
       obj.dirty[self.name] = True
 
-  def __del__(self, obj):
+  def __del__(self, obj=None):
     """Delete value of this attribute."""
+    if not obj:
+      return
+
     del obj.attr[self.name]
     if obj.dirty.get(self.name) is not None:
       del obj.dirty[self.name]


### PR DESCRIPTION
This fixes issue #52 in which an Exception is raised when cleaning up on shutdown. The `del` is called on the `ApiAttribute` but without the required `obj` argument. A default `None` is added and checked for to eliminate this Exception.