### PR TITLE
Correcting hostname settings

### DIFF
--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -65,7 +65,8 @@
 <div><ol class="loweralpha simple">
 <li>Select &#8216;Application type&#8217; to be <em>Web application</em>.</li>
 <li>Click on &#8216;more options&#8217; in hostname settings</li>
-<li>Input <em>http://localhost:8080/</em> for both &#8216;Redirect URIs&#8217; and &#8216;JavaScript origins&#8217;.</li>
+<li>Input <em>http://localhost:8080</em> for &#8216;JavaScript origins&#8217;.</li>
+<li>Input <em>http://localhost:8080/</em> for &#8216;Redirect URIs&#8217;.</li>
 </ol>
 </div></blockquote>
 <ol class="arabic simple" start="4">


### PR DESCRIPTION
Google doesn't allow the 'JavaScript origins' hostname to end with a '/'. This changes the quickstart guide and corrects the information. Fixes #49