### PR TITLE
Support uploading large files

### DIFF
--- a/pydrive/files.py
+++ b/pydrive/files.py
@@ -299,7 +299,7 @@ class GoogleDriveFile(ApiAttributeMixin, ApiResource):
     """
     if self.get('mimeType') is None:
       self['mimeType'] = 'application/octet-stream'
-    return MediaIoBaseUpload(self.content, self['mimeType'])
+    return MediaIoBaseUpload(self.content, self['mimeType'], resumable=True)
 
   @LoadAuth
   def _DownloadFromUrl(self, url):


### PR DESCRIPTION
https://github.com/googledrive/PyDrive/issues/27
https://github.com/googledrive/PyDrive/issues/55

Reading the code for apiclient.http.MediaIoBaseUpload at
https://github.com/google/google-api-python-client/blob/master
/googleapiclient/http.py , it would seem the simply setting
resumable=True should be enough let it select a chunk size for
itself, thus precluding loading the entire file into memory.

Additionally, I just tested this with a 4Gb file, which is way larger than what has failed for me before