### PR TITLE
oauth2client 4.0.0 update compatibility 

### DIFF
--- a/pydrive/auth.py
+++ b/pydrive/auth.py
@@ -12,10 +12,9 @@ from oauth2client.client import AccessTokenRefreshError
 from oauth2client.client import OAuth2WebServerFlow
 from oauth2client.client import OOB_CALLBACK_URN
 from oauth2client.file import Storage
-from oauth2client.file import CredentialsFileSymbolicLinkError
 from oauth2client.tools import ClientRedirectHandler
 from oauth2client.tools import ClientRedirectServer
-from oauth2client.util import scopes_to_string
+from oauth2client._helpers import scopes_to_string
 from .apiattr import ApiAttribute
 from .apiattr import ApiAttributeMixin
 from .settings import LoadSettingsFile
@@ -307,7 +306,7 @@ class GoogleAuth(ApiAttributeMixin, object):
     try:
       storage = Storage(credentials_file)
       self.credentials = storage.get()
-    except CredentialsFileSymbolicLinkError:
+    except IOError:
       raise InvalidCredentialsError('Credentials file cannot be symbolic link')
 
   def SaveCredentials(self, backend=None):
@@ -346,7 +345,7 @@ class GoogleAuth(ApiAttributeMixin, object):
       storage = Storage(credentials_file)
       storage.put(self.credentials)
       self.credentials.set_store(storage)
-    except CredentialsFileSymbolicLinkError:
+    except IOError:
       raise InvalidCredentialsError('Credentials file cannot be symbolic link')
 
   def LoadClientConfig(self, backend=None):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "google-api-python-client >= 1.2",
+        "oauth2client >= 4.0.0
         "PyYAML >= 3.0",
     ],
 )


### PR DESCRIPTION
Tests passed for me except:

test_Parallel_Files_Insert_File_Auto_Generated_HTTP
and
test_Parallel_Insert_File_Passed_HTTP

which I believe are because the call to signal.SIGALRM in timeout_decorator doesn't work on Windows machine.

If need be I can find a workaround to make these tests pass on Windows