### PR TITLE
Change "application type" to "other"

### DIFF
--- a/docs/build/html/_sources/quickstart.txt
+++ b/docs/build/html/_sources/quickstart.txt
@@ -10,11 +10,9 @@ Drive API requires OAuth2.0 for authentication. *PyDrive* makes your life much e
 3. Select 'Credentials' from the left menu, click 'Create Credentials', select 'OAuth client ID'.
 4. Now, the product name and consent screen need to be set -> click 'Configure consent screen' and follow the instructions. Once finished:
 
- a. Select 'Application type' to be *Web application*.
+ a. Select 'Application type' to be *Other*.
  b. Enter an appropriate name.
- c. Input *http://localhost:8080* for 'Authorized JavaScript origins'.
- d. Input *http://localhost:8080/* for 'Authorized redirect URIs'.
- e. Click 'Create'.
+ c. Click 'Create'.
 
 5. Click 'Download JSON' on the right side of Client ID to download **client_secret_<really long ID>.json**.
 


### PR DESCRIPTION
Otherwise, `quickstart.py` fails with:
````
400. That’s an error.

Error: redirect_uri_mismatch

The redirect URI in the request, http://localhost:8080/, does not match the ones authorized for the OAuth client. Visit https://console.developers.google.com/apis/credentials/oauthclient/331538535722-b3ds7cpjs47ku6u2ecqbmaqgub7e1qeh.apps.googleusercontent.com?project=331538535722 to update the authorized redirect URIs.

Learn more

Request Details
scope=https://www.googleapis.com/auth/drive
redirect_uri=http://localhost:8080/
response_type=code
client_id=
193838929292-dkkdie3833kd39ddlpei32i2d33k3mdkd.apps.googleusercontent.com
access_type=offline
That’s all we know.
````